### PR TITLE
LUN-2767: Allow using different implementations for site caching.

### DIFF
--- a/multisiteauth/middleware.py
+++ b/multisiteauth/middleware.py
@@ -4,7 +4,6 @@ import re
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from django.contrib.sites.models import Site
 from django.core.exceptions import MiddlewareNotUsed
 
 from multisiteauth import settings as local_settings
@@ -32,7 +31,7 @@ class BasicAuthProtectionMiddleware(object):
 
     def process_request(self, request):
         # adapted from https://github.com/amrox/django-moat/blob/master/moat/middleware.py
-        current_site = Site.objects.get_current()
+        current_site = local_settings.get_current_site(request)
         if hasattr(current_site, 'siteauthorizationstatus'):
             auth_status = getattr(current_site, 'siteauthorizationstatus', None)
             if auth_status and auth_status.require_basic_authentication:

--- a/multisiteauth/settings.py
+++ b/multisiteauth/settings.py
@@ -1,4 +1,7 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.module_loading import import_string
+
 
 HTTP_AUTH_ENABLED = getattr(settings, 'BASIC_HTTP_AUTH_ENABLED', False)
 HTTP_AUTH_GENERAL_USERNAME = getattr(settings, 'BASIC_HTTP_AUTH_GENERAL_USERNAME', '')
@@ -6,3 +9,14 @@ HTTP_AUTH_GENERAL_PASS = getattr(settings, 'BASIC_HTTP_AUTH_GENERAL_PASS', '')
 HTTP_AUTH_ALLOW_ADMIN = getattr(settings, 'BASIC_HTTP_AUTH_ALLOW_ADMIN', True)
 HTTP_AUTH_REALM = getattr(settings, 'BASIC_HTTP_AUTH_REALM', '')
 HTTP_AUTH_URL_EXCEPTIONS = getattr(settings, 'BASIC_HTTP_AUTH_URL_EXCEPTIONS', [])
+
+HTTP_AUTH_GET_CURRENT_SITE = getattr(
+    settings,
+    'BASIC_HTTP_AUTH_GET_CURRENT_SITE',
+    'django.contrib.sites.shortcuts.get_current_site')
+
+try:
+    get_current_site = import_string(HTTP_AUTH_GET_CURRENT_SITE)
+except ImportError as exc:
+    err_msg = "Cannot import {}! This is used to get the current site."
+    raise ImproperlyConfigured(err_msg)


### PR DESCRIPTION
The Django implementation uses global variables and does not work with multiple processes.
This way we can use the hostedbento implementation which uses the cache to achieve the same thing.